### PR TITLE
ci: add GitHub Actions pipeline (lint, typecheck, build, env guard)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type-check
+        run: npx tsc --noEmit
+
+      - name: Check Supabase env vars are configured
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+        run: |
+          if [ -z "$NEXT_PUBLIC_SUPABASE_URL" ] || [ -z "$NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY" ]; then
+            echo "::error::Supabase env vars are not configured in repo secrets (NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY)."
+            exit 1
+          fi
+          echo "Supabase env vars are present."
+
+      - name: Build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+        run: npm run build

--- a/docs/entscheidungen.md
+++ b/docs/entscheidungen.md
@@ -29,6 +29,24 @@ Datenisolation wird über Row Level Security (RLS) sichergestellt; "Automaticall
 expose new tables" wurde bewusst deaktiviert, RLS-Policies werden pro Tabelle
 explizit geschrieben.
 
+## Containerisierung (Docker)
+
+Entscheid: kein Docker. Begründung: Vercel baut und betreibt Next.js nativ
+ohne Container; ein Dockerfile würde nur zusätzlichen Wartungsaufwand bringen
+(Build-Zeiten, Lernaufwand) ohne Mehrwert für Deployment oder Team-Setup, da
+`npm install` + `.env.local.example` bereits eine konsistente Dev-Umgebung
+sicherstellen.
+
+## CI/CD-Pipeline
+
+Entscheid: GitHub Actions Workflow (`.github/workflows/ci.yml`), der bei jedem
+Pull Request und Push auf `main`/`dev` Lint, TypeScript-Check, eine Prüfung der
+Supabase-Umgebungsvariablen sowie den Produktions-Build ausführt. Ergänzt durch
+Vercel Preview-Deployments pro Pull Request (automatisch via GitHub-Integration).
+Begründung: verhindert, dass kaputter Code in `main`/`dev` gelangt; liefert
+nachvollziehbare Qualitätssicherung für A-10/A-11 und sofort testbare Preview-
+Links für die Demo.
+
 ## Build-Reihenfolge
 
 Notizen → Todos → Pomodoro → Dashboard, da das Dashboard die Daten der


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions CI workflow that runs on every PR/push to `main`/`dev`: install, lint, typecheck, a Supabase env-var presence guard, and a production build
- Documents the decisions to skip Docker (Vercel builds Next.js natively) and adopt this CI/CD pipeline in `docs/entscheidungen.md` (A-1/A-9)

## Test plan
- [ ] Confirm the workflow runs and passes on this PR (Actions tab)
- [ ] Add `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` as repo secrets so the build/env-guard steps succeed
- [ ] Verify the env-guard step fails the build if secrets are missing (sanity check by temporarily removing one)