### PR TITLE
ci: bump checkout/setup-node to v5 (Node.js 24 runners)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       run:
         working-directory: app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` and `actions/setup-node` from v4 to v5 to clear the Node.js 20 deprecation warning (runners move to Node 24 by default on 2026-06-16)

## Test plan
- [x] Confirm the CI run on this PR completes without the Node.js 20 deprecation warning