### PR TITLE
docs: drop the never-used dev branch from workflow and CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main]
   push:
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   build:

--- a/docs/entscheidungen.md
+++ b/docs/entscheidungen.md
@@ -40,12 +40,24 @@ sicherstellen.
 ## CI/CD-Pipeline
 
 Entscheid: GitHub Actions Workflow (`.github/workflows/ci.yml`), der bei jedem
-Pull Request und Push auf `main`/`dev` Lint, TypeScript-Check, eine Prüfung der
+Pull Request und Push auf `main` Lint, TypeScript-Check, eine Prüfung der
 Supabase-Umgebungsvariablen sowie den Produktions-Build ausführt. Ergänzt durch
 Vercel Preview-Deployments pro Pull Request (automatisch via GitHub-Integration).
-Begründung: verhindert, dass kaputter Code in `main`/`dev` gelangt; liefert
+Begründung: verhindert, dass kaputter Code in `main` gelangt; liefert
 nachvollziehbare Qualitätssicherung für A-10/A-11 und sofort testbare Preview-
 Links für die Demo.
+
+## Branch-Modell: kein `dev`-Branch
+
+Frühe Planungsnotizen (STRATEGY.md, CLAUDE.md) erwähnten ein `dev`-`main`-Modell
+mit Feature-Branches gegen `dev`. In der Praxis liefen alle bisherigen PRs
+(#1–#4) bereits direkt gegen `main` — ein `dev`-Branch wurde nie angelegt.
+Entscheid: bei einem Single-Branch-Modell bleiben (Feature-Branches direkt
+gegen `main`, PR + Review vor Merge). Begründung: für ein 3–5-köpfiges Team
+mit kurzer Projektdauer reduziert ein zusätzlicher Integrations-Branch nur
+die Übersicht, ohne einen echten Mehrwert zu bieten — das bestehende
+PR-Review-Gate auf `main` erfüllt denselben Zweck (A-11). Die Planungsdokumente
+und CI-Konfiguration wurden entsprechend korrigiert.
 
 ## Build-Reihenfolge
 


### PR DESCRIPTION
## Summary
- One trailing commit (`ac2b609`) on `feature/auth` landed after PR #4 was already merged, so it never made it into `main`
- Corrects planning docs (`entscheidungen.md`, `STRATEGY.md`, `CLAUDE.md`) and `.github/workflows/ci.yml` to reflect that the project never used a `dev` branch — single-branch flow (`feature/X` → `main`) is and always was the actual model
- Also propagates the same correction to GitHub issues #5–#8

## Test plan
- [ ] Docs-only + CI config change — no app behavior affected, build/lint/typecheck via CI is sufficient