### PR TITLE
feat(dashboard): aggregierte Übersicht aus Notizen, Todos, Pomodoro

### DIFF
--- a/app/src/app/dashboard/SummaryCard.tsx
+++ b/app/src/app/dashboard/SummaryCard.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+type SummaryCardProps = {
+  title: string;
+  /** Emoji als schlichtes Icon — kein zusätzliches Icon-Paket nötig. */
+  icon: string;
+  /** Tailwind-Klassen für den farbigen Icon-Chip (visuelle Hierarchie). */
+  accent: string;
+  /** Ziel-Modulseite, auf die die Karte verlinkt. */
+  href: string;
+  linkLabel: string;
+  /** Prominente Kennzahl oben rechts. */
+  total: ReactNode;
+  totalLabel: string;
+  children: ReactNode;
+  className?: string;
+};
+
+/**
+ * Wiederverwendbare Übersichtskarte für das Dashboard (Notizen, Todos,
+ * Pomodoro). Rein präsentational — die Daten werden in der Server Component
+ * geladen und als Props/Children hereingereicht.
+ */
+export function SummaryCard({
+  title,
+  icon,
+  accent,
+  href,
+  linkLabel,
+  total,
+  totalLabel,
+  children,
+  className,
+}: SummaryCardProps) {
+  return (
+    <section
+      className={`flex flex-col gap-5 rounded-2xl border border-black/[.08] bg-white p-6 shadow-sm transition-shadow hover:shadow-md dark:border-white/[.145] dark:bg-zinc-950 ${
+        className ?? ""
+      }`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <span
+            aria-hidden
+            className={`flex h-10 w-10 items-center justify-center rounded-xl text-xl ${accent}`}
+          >
+            {icon}
+          </span>
+          <h2 className="text-lg font-semibold text-black dark:text-zinc-50">
+            {title}
+          </h2>
+        </div>
+        <div className="text-right">
+          <div className="text-2xl font-bold leading-none text-black dark:text-zinc-50">
+            {total}
+          </div>
+          <div className="text-xs text-zinc-500 dark:text-zinc-400">
+            {totalLabel}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1">{children}</div>
+
+      <Link
+        href={href}
+        className="text-sm font-medium text-black underline-offset-4 hover:underline dark:text-zinc-50"
+      >
+        {linkLabel} →
+      </Link>
+    </section>
+  );
+}

--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -110,9 +110,25 @@ export default async function DashboardPage() {
   const pomodoroTotal = pomodoroTotalRes.count ?? 0;
   const pomodoroToday = pomodoroTodayRes.count ?? 0;
 
+  // Fehler aus einer der parallelen Queries sichtbar machen, statt sie als
+  // leere Übersicht ("0 Notizen") zu kaschieren.
+  const queryError =
+    notesRes.error ??
+    openTodosRes.error ??
+    doneTodosRes.error ??
+    pomodoroTotalRes.error ??
+    pomodoroTodayRes.error;
+
   return (
     <div className="flex flex-1 flex-col bg-zinc-50 dark:bg-black">
       <main className="mx-auto w-full max-w-5xl px-4 py-10 sm:px-6">
+        {queryError && (
+          <p className="mb-6 rounded-md bg-red-50 px-4 py-3 text-sm text-red-800 dark:bg-red-950 dark:text-red-200">
+            Dashboard-Daten konnten nicht geladen werden. Bitte versuche es
+            später erneut.
+          </p>
+        )}
+
         <header className="mb-8 flex flex-wrap items-start justify-between gap-4">
           <div>
             <p className="text-sm text-zinc-500 dark:text-zinc-400">

--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -1,0 +1,257 @@
+import Link from "next/link";
+
+import { logout } from "../login/actions";
+import { createClient } from "@/lib/supabase/server";
+import { SummaryCard } from "./SummaryCard";
+
+type RecentNote = { id: string; title: string; updated_at: string };
+type TopTodo = {
+  id: string;
+  title: string;
+  priority: "niedrig" | "mittel" | "hoch";
+};
+
+const priorityStyles: Record<TopTodo["priority"], string> = {
+  hoch: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-200",
+  mittel: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-200",
+  niedrig: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+};
+
+const priorityLabels: Record<TopTodo["priority"], string> = {
+  hoch: "Hoch",
+  mittel: "Mittel",
+  niedrig: "Niedrig",
+};
+
+const dateFormatter = new Intl.DateTimeFormat("de-CH", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+});
+
+function EmptyState({
+  text,
+  href,
+  cta,
+}: {
+  text: string;
+  href: string;
+  cta: string;
+}) {
+  return (
+    <p className="text-sm text-zinc-500 dark:text-zinc-400">
+      {text}{" "}
+      <Link
+        href={href}
+        className="font-medium text-black underline dark:text-zinc-50"
+      >
+        {cta}
+      </Link>
+    </p>
+  );
+}
+
+export default async function DashboardPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Start des heutigen Tages (Serverzeit) für die "heute"-Pomodoro-Zählung.
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+  const startOfTodayIso = startOfToday.toISOString();
+
+  // Alle Übersichts-Queries laufen PARALLEL (Promise.all) statt nacheinander —
+  // so entsteht kein Request-Wasserfall. Dank RLS liefert jede Query
+  // automatisch nur die Datensätze des eingeloggten Nutzers (kein zusätzlicher
+  // user_id-Filter im Code nötig). `count: "exact"` liefert die Gesamtzahl,
+  // während `limit`/`head` die übertragene Datenmenge klein hält.
+  const [
+    notesRes,
+    openTodosRes,
+    doneTodosRes,
+    pomodoroTotalRes,
+    pomodoroTodayRes,
+  ] = await Promise.all([
+    supabase
+      .from("notes")
+      .select("id, title, updated_at", { count: "exact" })
+      .order("updated_at", { ascending: false })
+      .limit(3),
+    supabase
+      .from("todos")
+      .select("id, title, priority", { count: "exact" })
+      .eq("is_done", false)
+      .order("priority", { ascending: false })
+      .limit(3),
+    supabase
+      .from("todos")
+      .select("id", { count: "exact", head: true })
+      .eq("is_done", true),
+    supabase.from("pomodoro_sessions").select("id", {
+      count: "exact",
+      head: true,
+    }),
+    supabase
+      .from("pomodoro_sessions")
+      .select("id", { count: "exact", head: true })
+      .gte("completed_at", startOfTodayIso),
+  ]);
+
+  const recentNotes = (notesRes.data ?? []) as RecentNote[];
+  const notesCount = notesRes.count ?? 0;
+
+  const topTodos = (openTodosRes.data ?? []) as TopTodo[];
+  const openTodosCount = openTodosRes.count ?? 0;
+  const doneTodosCount = doneTodosRes.count ?? 0;
+
+  const pomodoroTotal = pomodoroTotalRes.count ?? 0;
+  const pomodoroToday = pomodoroTodayRes.count ?? 0;
+
+  return (
+    <div className="flex flex-1 flex-col bg-zinc-50 dark:bg-black">
+      <main className="mx-auto w-full max-w-5xl px-4 py-10 sm:px-6">
+        <header className="mb-8 flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+              {dateFormatter.format(new Date())}
+            </p>
+            <h1 className="mt-1 text-2xl font-semibold text-black dark:text-zinc-50">
+              Willkommen zurück
+            </h1>
+            {user?.email && (
+              <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                Angemeldet als {user.email}
+              </p>
+            )}
+          </div>
+          <form>
+            <button
+              formAction={logout}
+              className="rounded-full border border-black/[.08] px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-black/[.04] dark:border-white/[.145] dark:text-zinc-50 dark:hover:bg-[#1a1a1a]"
+            >
+              Abmelden
+            </button>
+          </form>
+        </header>
+
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+          {/* Notizen */}
+          <SummaryCard
+            title="Notizen"
+            icon="📝"
+            accent="bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-200"
+            href="/notes"
+            linkLabel="Alle Notizen"
+            total={notesCount}
+            totalLabel={notesCount === 1 ? "Notiz" : "Notizen"}
+            className="md:col-span-2 xl:col-span-1"
+          >
+            {recentNotes.length > 0 ? (
+              <ul className="flex flex-col gap-1">
+                {recentNotes.map((note) => (
+                  <li key={note.id}>
+                    <Link
+                      href={`/notes/${note.id}`}
+                      className="flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm transition-colors hover:bg-black/[.04] dark:hover:bg-white/[.06]"
+                    >
+                      <span className="truncate font-medium text-black dark:text-zinc-50">
+                        {note.title}
+                      </span>
+                      <span className="shrink-0 text-xs text-zinc-500 dark:text-zinc-400">
+                        {dateFormatter.format(new Date(note.updated_at))}
+                      </span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <EmptyState
+                text="Noch keine Notizen."
+                href="/notes"
+                cta="Jetzt erstellen"
+              />
+            )}
+          </SummaryCard>
+
+          {/* Todos */}
+          <SummaryCard
+            title="Todos"
+            icon="✅"
+            accent="bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-200"
+            href="/todos"
+            linkLabel="Alle Todos"
+            total={openTodosCount}
+            totalLabel={`offen · ${doneTodosCount} erledigt`}
+          >
+            {topTodos.length > 0 ? (
+              <ul className="flex flex-col gap-1">
+                {topTodos.map((todo) => (
+                  <li
+                    key={todo.id}
+                    className="flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm"
+                  >
+                    <span className="truncate text-black dark:text-zinc-50">
+                      {todo.title}
+                    </span>
+                    <span
+                      className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${priorityStyles[todo.priority]}`}
+                    >
+                      {priorityLabels[todo.priority]}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <EmptyState
+                text={
+                  doneTodosCount > 0
+                    ? "Alles erledigt — keine offenen Todos."
+                    : "Noch keine Todos."
+                }
+                href="/todos"
+                cta="Jetzt erstellen"
+              />
+            )}
+          </SummaryCard>
+
+          {/* Pomodoro */}
+          <SummaryCard
+            title="Pomodoro"
+            icon="🍅"
+            accent="bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-200"
+            href="/pomodoro"
+            linkLabel="Zum Timer"
+            total={pomodoroToday}
+            totalLabel="heute abgeschlossen"
+          >
+            {pomodoroTotal > 0 ? (
+              <div className="flex flex-col gap-1">
+                <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                  Insgesamt{" "}
+                  <span className="font-semibold text-black dark:text-zinc-50">
+                    {pomodoroTotal}
+                  </span>{" "}
+                  {pomodoroTotal === 1 ? "Session" : "Sessions"} abgeschlossen
+                </p>
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                  {pomodoroToday > 0
+                    ? "Stark — weiter so!"
+                    : "Heute noch keine Session — Zeit für Fokus."}
+                </p>
+              </div>
+            ) : (
+              <EmptyState
+                text="Noch keine Sessions."
+                href="/pomodoro"
+                cta="Timer starten"
+              />
+            )}
+          </SummaryCard>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,28 +1,8 @@
-import { logout } from "./login/actions";
-import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
 
-export default async function Home() {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-6 bg-zinc-50 px-4 text-center dark:bg-black">
-      <h1 className="text-2xl font-semibold text-black dark:text-zinc-50">
-        Willkommen bei ProVity
-      </h1>
-      <p className="text-zinc-600 dark:text-zinc-400">
-        Angemeldet als {user?.email}
-      </p>
-      <form>
-        <button
-          formAction={logout}
-          className="rounded-full border border-black/[.08] px-5 py-2 text-sm font-medium text-black transition-colors hover:bg-black/[.04] dark:border-white/[.145] dark:text-zinc-50 dark:hover:bg-[#1a1a1a]"
-        >
-          Abmelden
-        </button>
-      </form>
-    </div>
-  );
+// Das Dashboard ist der Startbildschirm nach dem Login. Die Wurzel-Route leitet
+// dorthin um; nicht angemeldete Nutzer fängt vorher die proxy.ts-Middleware ab
+// und schickt sie auf /login.
+export default function Home() {
+  redirect("/dashboard");
 }

--- a/docs/ai-log.md
+++ b/docs/ai-log.md
@@ -36,6 +36,7 @@
 | 2026-06-08 | Claude | Feature-Issues (#5–#8) strukturieren, Schema- und RLS-Vorschläge | GitHub Issues Notizen/Todos/Pomodoro/Dashboard |
 | 2026-06-15 | Claude | Projektdokumentation strukturieren (Architektur-/DB-Diagramme, Zeitplan-Gerüst, IPA-Berichtsstruktur, Glossar, Testprotokoll-Vorlage) | `docs/` |
 | 2026-06-15 | Claude | SQL-Migrationen (notes/todos/pomodoro) gegen Supabase-Best-Practices prüfen & optimieren (`(select auth.uid())`, `to authenticated`, FK-Index, `with check`); Migrationsdateien anlegen, RLS-Entscheidung dokumentieren, Schema in Supabase verifizieren | `app/supabase/migrations/`, `docs/entscheidungen.md`, Issues #5–#7 |
+| 2026-06-15 | Claude | Dashboard (Issue #8) umsetzen: Server Component mit parallelem Datenladen (`Promise.all`) aus notes/todos/pomodoro_sessions, wiederverwendbare `SummaryCard`, Leerzustände, `/`→`/dashboard`-Redirect; lint/tsc/build geprüft | Dashboard-Feature (`app/src/app/dashboard/`, `app/src/app/page.tsx`) |
 
 <!-- Anleitung: Pro Feature führt zusätzlich jede Person ihre eigenen AI-Anfragen
 nach (siehe Hinweis in den Issues). Diese hier zentral zusammenführen. -->

--- a/docs/entscheidungen.md
+++ b/docs/entscheidungen.md
@@ -107,5 +107,31 @@ Sessions können nach dem Anlegen nicht mehr verändert oder gelöscht werden.
 Tabellen, nicht nur für die ursprünglichen Module — die Datenisolation greift
 also automatisch, ohne zusätzlichen Code.
 
+## Dashboard — Implementierung (Issue #8)
+
+**Startbildschirm: `/` leitet auf `/dashboard` um.** Optionen waren (a) das
+Dashboard direkt unter `/` rendern oder (b) eine eigene Route `/dashboard` und
+`/` per `redirect()` dorthin schicken. Gewählt: (b). Begründung: Die Issues
+listen `app/src/app/dashboard/page.tsx` als anzulegende Datei, und eine eigene,
+benennbare Route ist verlinkbar/teilbar; `/` bleibt als stabiler Einstiegspunkt
+nach dem Login (die `login`-Action redirectet weiterhin auf `/`). Verworfen:
+Dashboard-Logik in `page.tsx` der Wurzel — vermischt "Einstiegspunkt" und
+"Feature-Seite" und erschwert späteres Verlinken.
+
+**Datenladen parallel statt sequenziell.** Alle fünf Übersichts-Queries (Notizen
++ Anzahl, offene Todos + Anzahl, erledigte Todos, Pomodoro gesamt, Pomodoro
+heute) laufen in einem `Promise.all([...])`. Begründung: serielles `await` würde
+einen Request-Wasserfall erzeugen (Summe der Latenzen); parallel zählt nur die
+langsamste Query. Datenmenge wird klein gehalten über `count: "exact"` für
+Summen (mit `head: true`, wo keine Zeilen gebraucht werden) und `limit(3)` für
+die Listen — kein ungebremstes Laden aller Datensätze.
+
+**Abhängigkeit zu #5/#6/#7.** Das Dashboard liest aus `notes`, `todos`,
+`pomodoro_sessions` (Tabellen liegen bereits als Migrationen vor) und verlinkt
+auf `/notes`, `/todos`, `/pomodoro`. Diese Modul-Seiten entstehen in den
+parallelen Issues #5/#6/#7; bis zu deren Merge führen die Links ins Leere
+(404) — die Dashboard-Logik selbst ist davon unabhängig korrekt und baut/
+typprüft fehlerfrei (Next.js validiert `Link`-Ziele nicht zur Build-Zeit).
+
 <!-- Anleitung: jede relevante Entscheidung sofort nach dem Treffen eintragen,
 nicht rückwirkend rekonstruieren. -->

--- a/docs/entscheidungen.md
+++ b/docs/entscheidungen.md
@@ -133,5 +133,13 @@ parallelen Issues #5/#6/#7; bis zu deren Merge führen die Links ins Leere
 (404) — die Dashboard-Logik selbst ist davon unabhängig korrekt und baut/
 typprüft fehlerfrei (Next.js validiert `Link`-Ziele nicht zur Build-Zeit).
 
+**"Heute" für Pomodoro: Serverzeit (UTC).** Die "heute abgeschlossen"-Zählung
+nutzt `new Date().setHours(0,0,0,0)` auf dem Server. Auf Vercel läuft das auf
+UTC; für Nutzer in der Schweiz bedeutet das, dass Sessions erst ab 02:00 Uhr
+Ortszeit als "heute" gezählt werden. Bewusst akzeptiert für die erste Version,
+da eine korrekte clientseitige Zeitzonenbehandlung zusätzliche Komplexität
+bedeutet; falls nötig, wird dies in einem Folgeschritt über einen
+Zeitzonen-Offset aus dem Client gelöst.
+
 <!-- Anleitung: jede relevante Entscheidung sofort nach dem Treffen eintragen,
 nicht rückwirkend rekonstruieren. -->

--- a/docs/testkonzept.md
+++ b/docs/testkonzept.md
@@ -31,7 +31,7 @@ auf Desktop (Chrome, Firefox) und Mobile (Smartphone, als installierte PWA).
 | T-04 | Notizen | Erstellen/Bearbeiten/Löschen | Änderungen werden persistiert und korrekt angezeigt | offen |
 | T-05 | Todos | Erstellen, Priorität setzen, als erledigt markieren | Status/Priorität korrekt gespeichert und angezeigt | offen |
 | T-06 | Pomodoro | Start/Pause/Reset, Session-Zähler | Timer läuft korrekt, Zähler erhöht sich nach Intervall | offen |
-| T-07 | Dashboard | Aggregierte Anzeige (Timer, Notizen, Todos) | Aktuelle Daten aus allen Modulen sichtbar | offen |
+| T-07 | Dashboard | Aggregierte Anzeige (Notizen-Anzahl + 3 letzte, Todos offen/erledigt + Top-3, Pomodoro heute/gesamt), Karten verlinken auf die Module | Aktuelle, korrekte Daten aus allen drei Modulen sichtbar; Leerzustände bei fehlenden Daten | Code fertig, lint/tsc/build grün; manueller 2-Konten-Test offen |
 | T-08 | PWA | Installation auf Smartphone | App lässt sich installieren und startet eigenständig | offen |
 | T-09 | Responsive | Layout auf Mobile/Desktop | Keine Überlappungen, Bedienung möglich | offen |
 


### PR DESCRIPTION
## Ziel

Umsetzung von **Issue #8** — zentrale Übersichtsseite, die aggregierte Daten aus Notizen, Todos und Pomodoro anzeigt (Startbildschirm nach dem Login).

Closes #8

## Änderungen

- **`app/src/app/dashboard/page.tsx`** — Server Component, lädt **parallel** (`Promise.all`, kein Request-Wasserfall) aus `notes`, `todos`, `pomodoro_sessions`:
  - **Notizen:** Gesamtzahl + 3 zuletzt bearbeitete (verlinkt auf `/notes/[id]`)
  - **Todos:** offen/erledigt + Top-3 nach Priorität (farbige Badges)
  - **Pomodoro:** heute abgeschlossen + Gesamtzahl
  - Leerzustände pro Bereich, deutsche UI-Texte, Tailwind im Projektstil, responsives Bento-Grid
- **`app/src/app/dashboard/SummaryCard.tsx`** — wiederverwendbare Übersichtskarte
- **`app/src/app/page.tsx`** — `/` leitet auf `/dashboard` um (Startbildschirm)
- Doku: `entscheidungen.md` (Routing, paralleles Laden, Abhängigkeit), `ai-log.md`, `testkonzept.md` (T-07)

## Technische Hinweise

- Nutzt ausschliesslich `createClient` aus `@/lib/supabase/server`; rein lesend
- Datenisolation greift automatisch über die bestehenden **RLS-Policies** der drei Tabellen — keine eigene Tabelle/Policy nötig
- Queries begrenzt via `count: "exact"` (+ `head: true` wo keine Zeilen gebraucht) und `limit(3)` — kein ungebremstes Laden

## ⚠️ Abhängigkeit

Issue #8 setzt voraus, dass #5 (notes), #6 (todos), #7 (pomodoro) in `main` sind. Die DB-Tabellen liegen bereits als Migrationen vor, aber die Seiten `/notes`, `/todos`, `/pomodoro` entstehen in jenen Issues — bis zu deren Merge führen die Karten-Links ins Leere (404). Die Dashboard-Logik selbst ist davon unabhängig korrekt.

## Definition of Done

- [x] Dashboard zeigt aggregierte Daten aus allen drei Modulen
- [x] Daten werden parallel geladen (`Promise.all`, im Code nachvollziehbar)
- [x] `npm run lint`, `npx tsc --noEmit`, `npm run build` laufen fehlerfrei
- [ ] Manueller 2-Konten-Test (T-07/T-03) + Responsive (T-09) — durch Team in Live-Umgebung
- [ ] Review durch Teamleitung vor Merge

https://claude.ai/code/session_01B9j1XRb2MBqyEgVScp2awJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9j1XRb2MBqyEgVScp2awJ)_