### PR TITLE
fix(todos): auth guard + explicit user_id filter on mutations

### DIFF
--- a/app/src/app/todos/actions.ts
+++ b/app/src/app/todos/actions.ts
@@ -45,7 +45,20 @@ export async function createTodo(formData: FormData) {
 export async function toggleTodo(id: string, isDone: boolean) {
   const supabase = await createClient();
 
-  await supabase.from("todos").update({ is_done: isDone }).eq("id", id);
+  // Auth-Check + expliziter user_id-Filter als zweite Schutzschicht zur RLS.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return;
+  }
+
+  await supabase
+    .from("todos")
+    .update({ is_done: isDone })
+    .eq("id", id)
+    .eq("user_id", user.id);
 
   revalidatePath("/todos");
 }
@@ -57,7 +70,19 @@ export async function updateTodoPriority(id: string, priority: TodoPriority) {
     return;
   }
 
-  await supabase.from("todos").update({ priority }).eq("id", id);
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return;
+  }
+
+  await supabase
+    .from("todos")
+    .update({ priority })
+    .eq("id", id)
+    .eq("user_id", user.id);
 
   revalidatePath("/todos");
 }
@@ -65,7 +90,15 @@ export async function updateTodoPriority(id: string, priority: TodoPriority) {
 export async function deleteTodo(id: string) {
   const supabase = await createClient();
 
-  await supabase.from("todos").delete().eq("id", id);
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return;
+  }
+
+  await supabase.from("todos").delete().eq("id", id).eq("user_id", user.id);
 
   revalidatePath("/todos");
 }

--- a/app/src/app/todos/actions.ts
+++ b/app/src/app/todos/actions.ts
@@ -33,11 +33,15 @@ export async function createTodo(formData: FormData) {
     return;
   }
 
-  await supabase.from("todos").insert({
+  const { error } = await supabase.from("todos").insert({
     user_id: user.id,
     title,
     priority: VALID_PRIORITIES.includes(priority as TodoPriority) ? priority : "mittel",
   });
+
+  if (error) {
+    throw error;
+  }
 
   revalidatePath("/todos");
 }
@@ -54,11 +58,15 @@ export async function toggleTodo(id: string, isDone: boolean) {
     return;
   }
 
-  await supabase
+  const { error } = await supabase
     .from("todos")
     .update({ is_done: isDone })
     .eq("id", id)
     .eq("user_id", user.id);
+
+  if (error) {
+    throw error;
+  }
 
   revalidatePath("/todos");
 }
@@ -78,11 +86,15 @@ export async function updateTodoPriority(id: string, priority: TodoPriority) {
     return;
   }
 
-  await supabase
+  const { error } = await supabase
     .from("todos")
     .update({ priority })
     .eq("id", id)
     .eq("user_id", user.id);
+
+  if (error) {
+    throw error;
+  }
 
   revalidatePath("/todos");
 }
@@ -98,7 +110,15 @@ export async function deleteTodo(id: string) {
     return;
   }
 
-  await supabase.from("todos").delete().eq("id", id).eq("user_id", user.id);
+  const { error } = await supabase
+    .from("todos")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (error) {
+    throw error;
+  }
 
   revalidatePath("/todos");
 }


### PR DESCRIPTION
## Why
Follow-up from the post-merge security review of the Todos module (merged in #10). The review found **no live vulnerability** — RLS already isolates data per user — but flagged a defense-in-depth gap: three mutation server actions relied on RLS as their *only* protection layer.

## What
`toggleTodo`, `updateTodoPriority`, and `deleteTodo` now:
- verify the session via `supabase.auth.getUser()` (return early if unauthenticated)
- scope the query with `.eq("user_id", user.id)` in addition to `.eq("id", id)`

This matches the existing `createTodo` pattern. Behaviour is unchanged for legitimate users — RLS enforced the same boundary — but the actions no longer depend solely on RLS, per the project security rules and Next.js guidance to authorize inside each Server Action.

## Test plan
- [x] `npm ci` + `npm run lint` + `npx tsc --noEmit` + `npm run build` all pass locally
- [ ] Toggle / change priority / delete a todo as the owner → works
- [ ] CI green