### PR TITLE
fix(pwa): serve manifest.webmanifest publicly (middleware exclusion)

### DIFF
--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -48,6 +48,6 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|manifest.webmanifest|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };


### PR DESCRIPTION
Follow-up zu #17. Das Auth-Middleware (`proxy.ts`) fing `/manifest.webmanifest` ab und leitete ausgeloggte Requests auf `/login` um (307) — Browser/Lighthouse konnten das Manifest nicht laden. Fix: Pfad im `matcher` ausgeschlossen (analog zu Bildern/\_next).

Verifiziert: `build` grün, `eslint` exit 0. Nach Merge live testen: `curl https://provity.vercel.app/manifest.webmanifest` → 200 application/manifest+json.